### PR TITLE
Changed the way throwing objects worked. Added slow to the monster when it interacts with certain objects

### DIFF
--- a/Don't Move/Assets/Scripts/Monster Scripts/MonsterMovement.cs
+++ b/Don't Move/Assets/Scripts/Monster Scripts/MonsterMovement.cs
@@ -18,7 +18,8 @@ public class MonsterMovement : MonoBehaviour
     public GameObject monsterRig;
     private Animator _monsterAnimator;
     public bool isStunned;
-
+    public GameObject interactableObject;
+    [SerializeField] private bool isSlowed = false;
     private void Start()
     {
         _rb = gameObject.GetComponent<Rigidbody>();
@@ -113,6 +114,13 @@ public class MonsterMovement : MonoBehaviour
 
     private void OnCollisionEnter(Collision collision)
     {
+        if (collision.gameObject.layer == interactableObject.layer)
+        {
+            if (isSlowed == false)
+            {
+                StartCoroutine(Slowed());
+            }
+        }
         if (collision.gameObject.CompareTag("Player"))
         {
             Physics.IgnoreCollision(collision.collider, agent.GetComponent<Collider>());
@@ -128,6 +136,16 @@ public class MonsterMovement : MonoBehaviour
         _monsterAnimator.SetBool("Stunned", false);
         _monsterAnimator.Play("Roar");
         maxMoveSpeed *= 1.15f;
+    }
+    
+    IEnumerator Slowed()
+    {
+        isSlowed = true;
+        maxMoveSpeed = 2.25f;
+        agent.speed = maxMoveSpeed;
+        yield return new WaitForSeconds(5f);
+        isSlowed = false;
+        maxMoveSpeed = 5.5f;
     }
 
     public void TriggerStun(float duration)

--- a/Don't Move/Assets/Scripts/Player Scripts/GrabScript.cs
+++ b/Don't Move/Assets/Scripts/Player Scripts/GrabScript.cs
@@ -9,11 +9,22 @@ public class GrabScript : MonoBehaviour
    [Header("Grab Setup Variables")]
    public Transform grabPoint;
    private GameObject inGripObj;
+   private Hashtable throwSettings;
 
    [Header("Parameters")] 
    public float grabRange = 5.0f;
    public float grabSpeed = 100f;
    public float throwPower = 50f;
+
+   public void Start()
+   {
+      throwSettings = new Hashtable();
+      throwSettings.Add(1f, 15f);
+      throwSettings.Add(1.5f, 30f);
+      throwSettings.Add(0.05f, 1f);
+      throwSettings.Add(0.15f, 2f);
+   }
+
    public void Update()
    {
       CheckObject();
@@ -38,6 +49,16 @@ public class GrabScript : MonoBehaviour
       }
    }
 
+   private void OnCollisionEnter(Collision collision)
+   {
+      if (collision.gameObject.CompareTag("Grab Object"))
+      {
+         if (inGripObj != null)
+         {
+            Physics.IgnoreCollision(collision.collider, GetComponent<Collider>());
+         }
+      }
+   }
    public void CheckObject()
    {
       if (inGripObj != null)
@@ -45,8 +66,11 @@ public class GrabScript : MonoBehaviour
          if (Input.GetKeyDown(KeyCode.R))
          {
             GameObject thrownObject = inGripObj;
+            string key = thrownObject.gameObject.tag;
             Drop(inGripObj);
+            throwPower = (float)Convert.ToDouble(throwSettings[thrownObject.GetComponent<Rigidbody>().mass]);
             thrownObject.GetComponent<Rigidbody>().AddForce(transform.forward * throwPower, ForceMode.Impulse);
+            thrownObject = null;
          }
          else
          {


### PR DESCRIPTION
Specifically, the throwing now uses a hashtable to have custom throw power values for different objects. As for the monster slowing, it currently uses time to go off of, so if the player isn't moving there won't be any apparent effect. The effect can be scene and is most useful when the player is moving. 